### PR TITLE
Add syntax highlighting capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _site
 __pycache__
 .ipynb_checkpoints
 .db.json
+.idea

--- a/_config.yml
+++ b/_config.yml
@@ -59,4 +59,4 @@ exclude:
   - bin
 
 # Turn off built-in syntax highlighting.
-highlighter: false
+highlighter: pygments

--- a/_episodes/03-encodings-libraries.md
+++ b/_episodes/03-encodings-libraries.md
@@ -37,7 +37,7 @@ keypoints:
 
 GeoJSON Example:
 
-~~~
+{% highlight json %}
 {
   "type": "FeatureCollection",
   "features": [
@@ -65,8 +65,7 @@ GeoJSON Example:
     }
   ]
 }
-~~~
-{: .json}
+{% endhighlight %}
 
 
 ## GIS file formats, RDBMS

--- a/_episodes/04-geopandas-intro.md
+++ b/_episodes/04-geopandas-intro.md
@@ -48,7 +48,7 @@ GeoPandas is still young, but it builds on mature and stable and widely used pac
 We'll use these throughout the rest of the tutorial.
 
 
-```python
+{% highlight python %}
 %matplotlib inline
 
 import os
@@ -65,7 +65,7 @@ import geopandas as gpd
 from geopandas import GeoSeries, GeoDataFrame
 
 data_pth = "../data"
-```
+{% endhighlight %}
 
 
 ## 3. GeoSeries: The geometry building block
@@ -96,11 +96,11 @@ But enough theory! Let's get our hands dirty (so to speak) with code. We'll star
 ### Create a `GeoSeries` from a list of `shapely Point` objects constructed directly from `WKT` text (though you will rarely need this raw approach)
 
 
-```python
+{% highlight python %}
 from shapely.wkt import loads
 
 GeoSeries([loads('POINT(1 2)'), loads('POINT(1.5 2.5)'), loads('POINT(2 3)')])
-```
+{% endhighlight %}
 
 
 

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -20,6 +20,7 @@
     <link rel="stylesheet" type="text/css" href="{{ root }}/assets/css/bootstrap.css" />
     <link rel="stylesheet" type="text/css" href="{{ root }}/assets/css/bootstrap-theme.css" />
     <link rel="stylesheet" type="text/css" href="{{ root }}/assets/css/lesson.css" />
+    <link rel="stylesheet" type="text/css" href="{{ root }}/assets/css/pygments.css">
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>

--- a/assets/css/pygments.css
+++ b/assets/css/pygments.css
@@ -1,0 +1,61 @@
+.highlight .hll { background-color: #ffffcc }
+.highlight .c { color: #408080; font-style: italic } /* Comment */
+.highlight .err { border: 1px solid #FF0000 } /* Error */
+.highlight .k { color: #008000; font-weight: bold } /* Keyword */
+.highlight .o { color: #666666 } /* Operator */
+.highlight .cm { color: #408080; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #BC7A00 } /* Comment.Preproc */
+.highlight .c1 { color: #408080; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #408080; font-style: italic } /* Comment.Special */
+.highlight .gd { color: #A00000 } /* Generic.Deleted */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #FF0000 } /* Generic.Error */
+.highlight .gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #00A000 } /* Generic.Inserted */
+.highlight .go { color: #808080 } /* Generic.Output */
+.highlight .gp { color: #000080; font-weight: bold } /* Generic.Prompt */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.highlight .gt { color: #0040D0 } /* Generic.Traceback */
+.highlight .kc { color: #008000; font-weight: bold } /* Keyword.Constant */
+.highlight .kd { color: #008000; font-weight: bold } /* Keyword.Declaration */
+.highlight .kn { color: #008000; font-weight: bold } /* Keyword.Namespace */
+.highlight .kp { color: #008000 } /* Keyword.Pseudo */
+.highlight .kr { color: #008000; font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: #B00040 } /* Keyword.Type */
+.highlight .m { color: #666666 } /* Literal.Number */
+.highlight .s { color: #BA2121 } /* Literal.String */
+.highlight .na { color: #7D9029 } /* Name.Attribute */
+.highlight .nb { color: #008000 } /* Name.Builtin */
+.highlight .nc { color: #0000FF; font-weight: bold } /* Name.Class */
+.highlight .no { color: #880000 } /* Name.Constant */
+.highlight .nd { color: #AA22FF } /* Name.Decorator */
+.highlight .ni { color: #999999; font-weight: bold } /* Name.Entity */
+.highlight .ne { color: #D2413A; font-weight: bold } /* Name.Exception */
+.highlight .nf { color: #0000FF } /* Name.Function */
+.highlight .nl { color: #A0A000 } /* Name.Label */
+.highlight .nn { color: #0000FF; font-weight: bold } /* Name.Namespace */
+.highlight .nt { color: #008000; font-weight: bold } /* Name.Tag */
+.highlight .nv { color: #19177C } /* Name.Variable */
+.highlight .ow { color: #AA22FF; font-weight: bold } /* Operator.Word */
+.highlight .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight .mf { color: #666666 } /* Literal.Number.Float */
+.highlight .mh { color: #666666 } /* Literal.Number.Hex */
+.highlight .mi { color: #666666 } /* Literal.Number.Integer */
+.highlight .mo { color: #666666 } /* Literal.Number.Oct */
+.highlight .sb { color: #BA2121 } /* Literal.String.Backtick */
+.highlight .sc { color: #BA2121 } /* Literal.String.Char */
+.highlight .sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
+.highlight .s2 { color: #BA2121 } /* Literal.String.Double */
+.highlight .se { color: #BB6622; font-weight: bold } /* Literal.String.Escape */
+.highlight .sh { color: #BA2121 } /* Literal.String.Heredoc */
+.highlight .si { color: #BB6688; font-weight: bold } /* Literal.String.Interpol */
+.highlight .sx { color: #008000 } /* Literal.String.Other */
+.highlight .sr { color: #BB6688 } /* Literal.String.Regex */
+.highlight .s1 { color: #BA2121 } /* Literal.String.Single */
+.highlight .ss { color: #19177C } /* Literal.String.Symbol */
+.highlight .bp { color: #008000 } /* Name.Builtin.Pseudo */
+.highlight .vc { color: #19177C } /* Name.Variable.Class */
+.highlight .vg { color: #19177C } /* Name.Variable.Global */
+.highlight .vi { color: #19177C } /* Name.Variable.Instance */
+.highlight .il { color: #666666 } /* Literal.Number.Integer.Long */


### PR DESCRIPTION
## Overview

This PR is a follow up to #5, solves #3. It adds syntax highlighting into the software carpentry lesson.

The new syntax for code to add highlighting is now

```
{% highlight python %}
def hello():
    print('Hello')
{% endhighlight %}
```

## Demo
<img width="535" alt="screenshot 2017-08-17 20 34 36" src="https://user-images.githubusercontent.com/17802172/29443257-b9239b08-838b-11e7-9f6e-2dbfdfc25069.png">
